### PR TITLE
SHA-384 typo fix

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1339,7 +1339,7 @@ std::string CertificateFingerprint::AlgorithmIdentifier(
 	case CertificateFingerprint::Algorithm::Sha256:
 		return "sha-256";
 	case CertificateFingerprint::Algorithm::Sha384:
-		return "sha-256";
+		return "sha-384";
 	case CertificateFingerprint::Algorithm::Sha512:
 		return "sha-512";
 	default:


### PR DESCRIPTION
There was a misspelling sha-384 with sha-256 typo which effectively lead to broken further fingerprint parsing.  This bug currently affects OBS 30.2.3 
Was reproduced with libwebrtc server